### PR TITLE
[perf] remove msg copy,remove goroutine in getOrCreateGroup

### DIFF
--- a/pkg/hls/muxer.go
+++ b/pkg/hls/muxer.go
@@ -241,7 +241,10 @@ func (m *Muxer) cacheAACSeqHeader(msg rtmp.AVMsg) {
 }
 
 func (m *Muxer) cacheSPSPPS(msg rtmp.AVMsg) {
-	m.spspps = msg.Payload
+	// 分配新内存来缓存SPS_PPS的msg
+	// 这样就可以不依赖func (group *Group) OnReadRTMPAVMsg中的msg变量
+	m.spspps = make([]byte,len(msg.Payload))
+	copy(m.spspps,msg.Payload)
 }
 
 func (m *Muxer) appendSPSPPS(out []byte) []byte {

--- a/pkg/logic/group.go
+++ b/pkg/logic/group.go
@@ -275,9 +275,10 @@ func (group *Group) OnReadRTMPAVMsg(msg rtmp.AVMsg) {
 	group.mutex.Lock()
 	defer group.mutex.Unlock()
 
-	p := make([]byte, len(msg.Payload))
-	copy(p, msg.Payload)
-	msg.Payload = p
+	//因为group.broadcastRTMP和group.hlsMuxer.FeedRTMPMessage都不引用msg了,所以不需要复制数据了
+	//p := make([]byte, len(msg.Payload))
+	//copy(p, msg.Payload)
+	//msg.Payload = p
 
 	//nazalog.Debugf("%+v, %02x, %02x", msg.Header, msg.Payload[0], msg.Payload[1])
 	group.broadcastRTMP(msg)

--- a/pkg/logic/server_manager.go
+++ b/pkg/logic/server_manager.go
@@ -203,8 +203,11 @@ func (sm *ServerManager) getOrCreateGroup(appName string, streamName string) *Gr
 	if !exist {
 		group = NewGroup(appName, streamName)
 		sm.groupMap[streamName] = group
+
+		// 只在第1个ServerSession产生时启动这个group协程
+		// 注: 创建的group协程暂时做结构设计预留，现在并没有实际动作，以后可以用协程执行OnReadRTMPAVMsg中数据转发
+		go group.RunLoop()
 	}
-	go group.RunLoop()
 	return group
 }
 


### PR DESCRIPTION
1、优化掉func (group *Group) OnReadRTMPAVMsg函数中的msg复制，修改函数func (m *Muxer) cacheSPSPPS分配新内存来缓存SPS_PPS的msg
2、修改func (sm *ServerManager) getOrCreateGroup函数，只在第1个ServerSession产生时启动这个group协程