### PR TITLE
[feat] fallback to MD5 auth algorithm if missing auth algorithm

### DIFF
--- a/pkg/rtsp/auth.go
+++ b/pkg/rtsp/auth.go
@@ -66,6 +66,10 @@ func (a *Auth) FeedWwwAuthenticate(auths []string, username, password string) {
 	if a.Nonce == "" {
 		nazalog.Warnf("FeedWwwAuthenticate realm invalid. v=%s", s)
 	}
+	if a.Algorithm == "" {
+		a.Algorithm = AuthAlgorithm
+		nazalog.Warnf("FeedWwwAuthenticate algorithm not found fallback to %s. v=%s", AuthAlgorithm, s)
+	}
 	if a.Algorithm != AuthAlgorithm {
 		nazalog.Warnf("FeedWwwAuthenticate algorithm invalid, only support MD5. v=%s", s)
 	}


### PR DESCRIPTION
海康某一款摄像头返回的认证信息中不包含 algorithm 信息，但是可以使用 md5 来进行认证
Digest realm="IP Camera(F5390)", nonce="21485f706d35a19f62245161867144d6", stale="FALSE"