### PR TITLE
修复http api /api/ctrl/start_relay_pull无法工作的bug.

### DIFF
--- a/pkg/logic/http_api.go
+++ b/pkg/logic/http_api.go
@@ -109,7 +109,7 @@ func (h *HttpApiServer) ctrlStartRelayPullHandler(w http.ResponseWriter, req *ht
 	var v base.ApiCtrlStartRelayPull
 	var info base.ApiCtrlStartRelayPullReq
 
-	j, err := unmarshalRequestJsonBody(req, info, "url")
+	j, err := unmarshalRequestJsonBody(req, &info, "url")
 	if err != nil {
 		Log.Warnf("http api start pull error. err=%+v", err)
 		v.ErrorCode = base.ErrorCodeParamMissing


### PR DESCRIPTION
解决发送http api /api/ctrl/start_relay_pull会提示
`http api start pull error. err=json: Unmarshal(non-pointer base.ApiCtrlStartRelayPullReq) - http_api.go:114`
的bug。