### PR TITLE
[feat] avpacket2rtmp 单元一次性分配空间增大，防止分配空间不足

### DIFF
--- a/pkg/remux/avpacket2rtmp.go
+++ b/pkg/remux/avpacket2rtmp.go
@@ -169,7 +169,7 @@ func (r *AvPacket2RtmpRemuxer) FeedAvPacket(pkt base.AvPacket) {
 		}
 
 		pos := 5
-		maxLength := len(pkt.Payload) + pos
+		maxLength := len(pkt.Payload) + pos + len(nals)*4
 		payload := make([]byte, maxLength)
 
 		for _, nal := range nals {


### PR DESCRIPTION
maxLength := len(pkt.Payload) + pos，可能会导致分配的内存不足的情况