### PR TITLE
add ModConfigGroupCreator to modify group config before created

### DIFF
--- a/pkg/logic/group_manager.go
+++ b/pkg/logic/group_manager.go
@@ -14,6 +14,8 @@ type IGroupCreator interface {
 	CreateGroup(appName, streamName string) *Group
 }
 
+type ModConfigGroupCreator func(appName, streamName string, baseConfig *Config)
+
 // IGroupManager
 //
 // 封装管理Group的容器

--- a/pkg/logic/logic.go
+++ b/pkg/logic/logic.go
@@ -93,6 +93,12 @@ type Option struct {
 	// 注意，如果业务方实现了自己的事件监听，则lal server内部不再走http notify的逻辑（也即二选一）。
 	//
 	NotifyHandler INotifyHandler
+
+	// ModConfigGroupCreator
+	// This func help us modify the group configuration base on appName or streamName
+	// so that group can have it own configuration (configuration can be in other source like db)
+	// It will help us reduce resource usage if we just want some specific group record flv or hls...
+	ModConfigGroupCreator ModConfigGroupCreator
 }
 
 var defaultOption = Option{

--- a/pkg/logic/server_manager__.go
+++ b/pkg/logic/server_manager__.go
@@ -621,7 +621,15 @@ func (sm *ServerManager) OnDelRtspSubSession(session *rtsp.SubSession) {
 // ----- implement IGroupCreator interface -----------------------------------------------------------------------------
 
 func (sm *ServerManager) CreateGroup(appName string, streamName string) *Group {
-	return NewGroup(appName, streamName, sm.config, sm)
+	var config *Config
+	if sm.option.ModConfigGroupCreator != nil {
+		cloneConfig := *sm.config
+		sm.option.ModConfigGroupCreator(appName, streamName, &cloneConfig)
+		config = &cloneConfig
+	} else {
+		config = sm.config
+	}
+	return NewGroup(appName, streamName, config, sm)
 }
 
 // ----- implement IGroupObserver interface -----------------------------------------------------------------------------


### PR DESCRIPTION
Example usage:
```
server := logic.NewServerManager(func(option *logic.Option) {
	option.ConfFilename = confFilename
	option.ModConfigGroupCreator = func(appName, streamName string, baseConfig *logic.Config) {
	        configFromDB := getConfigFromDBOrCache(appName, streamName)
		baseConfig.RecordConfig.EnableFlv = configFromDB.EnableFlv
		baseConfig.RecordConfig.EnableMpegts = configFromDB.EnableFlv
	}
})
```