### PR TITLE
Added application/json header for API responses

### DIFF
--- a/pkg/logic/http_api.go
+++ b/pkg/logic/http_api.go
@@ -216,6 +216,7 @@ func (h *HttpApiServer) notFoundHandler(w http.ResponseWriter, req *http.Request
 func feedback(v interface{}, w http.ResponseWriter) {
 	resp, _ := json.Marshal(v)
 	w.Header().Add("Server", base.LalHttpApiServer)
+	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(resp)
 }
 


### PR DESCRIPTION
Send `application/json` header so client libraries can automatically parse/unmarshal the response