### PR TITLE
pr 修改hls拉流时 获取流名称异常的情况

### DIFF
--- a/pkg/hls/path_strategy.go
+++ b/pkg/hls/path_strategy.go
@@ -34,7 +34,6 @@ type IPathStrategy interface {
 //
 // 路由策略
 // 接到HTTP请求时，对应文件路径的映射逻辑
-//
 type IPathRequestStrategy interface {
 	// GetRequestInfo
 	//
@@ -87,7 +86,6 @@ const (
 // - test110-1620540716095-1.ts
 // - ...                        一系列的TS文件
 //
-//
 // 假设
 // 流名称="test110"
 // rootPath="/tmp/lal/hls/"
@@ -100,7 +98,6 @@ const (
 // http://127.0.0.1:8080/hls/test110.m3u8                       -> /tmp/lal/hls/test110/playlist.m3u8
 // http://127.0.0.1:8080/hls/test110-1620540712084-0.ts         -> /tmp/lal/hls/test110/test110-1620540712084-0.ts
 // 最下面这两个做了特殊映射
-//
 type DefaultPathStrategy struct {
 }
 
@@ -113,7 +110,6 @@ type DefaultPathStrategy struct {
 // /hls/test110/record.m3u8               -> record.m3u8               test110    m3u8     {rootOutPath}/test110/record.m3u8
 // /hls/test110/test110-1620540712084-.ts -> test110-1620540712084-.ts test110    ts       {rootOutPath/test110/test110-1620540712084-.ts
 // /hls/test110-1620540712084-.ts         -> test110-1620540712084-.ts test110    ts       {rootOutPath/test110/test110-1620540712084-.ts
-//
 func (dps *DefaultPathStrategy) GetRequestInfo(urlCtx base.UrlContext, rootOutPath string) (ri RequestInfo) {
 	filename := urlCtx.LastItemOfPath
 	filetype := urlCtx.GetFileType()
@@ -158,5 +154,16 @@ func (*DefaultPathStrategy) GetTsFileName(streamName string, index int, timestam
 }
 
 func (*DefaultPathStrategy) getStreamNameFromTsFileName(fileName string) string {
-	return strings.Split(fileName, "-")[0]
+	sum := 0
+	index := strings.LastIndexFunc(fileName, func(r rune) bool {
+		if r == '-' {
+			sum++
+		}
+		// GetTsFileName 格式固定为%s-%d-%d.ts streamName取%s部分
+		return sum == 2
+	})
+	if index == -1 {
+		return fileName
+	}
+	return fileName[:index]
 }

--- a/pkg/hls/path_strategy_test.go
+++ b/pkg/hls/path_strategy_test.go
@@ -9,6 +9,7 @@
 package hls_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/q191201771/lal/pkg/base"
@@ -18,36 +19,100 @@ import (
 )
 
 func TestDefaultPathStrategy_GetRequestInfo(t *testing.T) {
-	dps := &hls.DefaultPathStrategy{}
-	rootOutPath := "/tmp/lal/hls/"
-
-	golden := map[string]hls.RequestInfo{
-		"http://127.0.0.1:8080/hls/test110.m3u8": {
-			StreamName:       "test110",
-			FileNameWithPath: "/tmp/lal/hls/test110/playlist.m3u8",
+	testCases := []struct {
+		name                    string
+		url                     string
+		wantStreamName          string
+		wantFileNameWithPath    string
+		wantWinFileNameWithPath string
+	}{
+		{
+			name:                    "1 hls/[].m3u8 格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test1.m3u8",
+			wantStreamName:          "test1",
+			wantFileNameWithPath:    "/tmp/lal/hls/test1/playlist.m3u8",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test1\\playlist.m3u8",
 		},
-		"http://127.0.0.1:8080/hls/test110/playlist.m3u8": {
-			StreamName:       "test110",
-			FileNameWithPath: "/tmp/lal/hls/test110/playlist.m3u8",
+		{
+			name:                    "2 hls/[]/playlist.m3u8 格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test2.m3u8",
+			wantStreamName:          "test2",
+			wantFileNameWithPath:    "/tmp/lal/hls/test2/playlist.m3u8",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test2\\playlist.m3u8",
 		},
-		"http://127.0.0.1:8080/hls/test110/record.m3u8": {
-			StreamName:       "test110",
-			FileNameWithPath: "/tmp/lal/hls/test110/record.m3u8",
+		{
+			name:                    "3 hls/[]/record.m3u8 格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test3/record.m3u8",
+			wantStreamName:          "test3",
+			wantFileNameWithPath:    "/tmp/lal/hls/test3/record.m3u8",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test3\\record.m3u8",
 		},
-		"http://127.0.0.1:8080/hls/test110/test110-1620540712084-0.ts": {
-			StreamName:       "test110",
-			FileNameWithPath: "/tmp/lal/hls/test110/test110-1620540712084-0.ts",
+		{
+			name:                    "4 hls/[]/[]-timestamp-seq.ts 格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test4/test4-1620540712084-0.ts",
+			wantStreamName:          "test4",
+			wantFileNameWithPath:    "/tmp/lal/hls/test4/test4-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test4\\test4-1620540712084-0.ts",
 		},
-		"http://127.0.0.1:8080/hls/test110-1620540712084-0.ts": {
-			StreamName:       "test110",
-			FileNameWithPath: "/tmp/lal/hls/test110/test110-1620540712084-0.ts",
+		{
+			name:                    "5 hls/[]-timestamp-seq.ts 格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test5-1620540712084-0.ts",
+			wantStreamName:          "test5",
+			wantFileNameWithPath:    "/tmp/lal/hls/test5/test5-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test5\\test5-1620540712084-0.ts",
+		},
+		{
+			name:                    "6 hls/[]/[]-timestamp-seq.ts 名称带-符号格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test6/test6-0-1620540712084-0.ts",
+			wantStreamName:          "test6-0",
+			wantFileNameWithPath:    "/tmp/lal/hls/test6-0/test6-0-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test6-0\\test6-0-1620540712084-0.ts",
+		},
+		{
+			name:                    "7 hls/[]-timestamp-seq.ts 名称带-符号格式测试",
+			url:                     "http://127.0.0.1:8080/hls/test7-0-1620540712084-0.ts",
+			wantStreamName:          "test7-0",
+			wantFileNameWithPath:    "/tmp/lal/hls/test7-0/test7-0-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\test7-0\\test7-0-1620540712084-0.ts",
+		},
+		{
+			name:                    "8 hls/[]-timestamp-seq.ts 名称带中文测试",
+			url:                     "http://127.0.0.1:8080/hls/中文测试-1620540712084-0.ts",
+			wantStreamName:          "中文测试",
+			wantFileNameWithPath:    "/tmp/lal/hls/中文测试/中文测试-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\中文测试\\中文测试-1620540712084-0.ts",
+		},
+		{
+			name:                    "9 hls/[]-timestamp-seq.ts 名称带中文和-符号测试",
+			url:                     "http://127.0.0.1:8080/hls/中文测试-zh-0-1620540712084-0.ts",
+			wantStreamName:          "中文测试-zh-0",
+			wantFileNameWithPath:    "/tmp/lal/hls/中文测试-zh-0/中文测试-zh-0-1620540712084-0.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\中文测试-zh-0\\中文测试-zh-0-1620540712084-0.ts",
+		},
+		{
+			name:                    "10 hls/[]-timestamp.ts 非标准格式",
+			url:                     "http://127.0.0.1:8080/hls/中文测试-1620540712084.ts",
+			wantStreamName:          "中文测试-1620540712084.ts",
+			wantFileNameWithPath:    "/tmp/lal/hls/中文测试-1620540712084.ts/中文测试-1620540712084.ts",
+			wantWinFileNameWithPath: "\\tmp\\lal\\hls\\中文测试-1620540712084.ts\\中文测试-1620540712084.ts",
 		},
 	}
 
-	for k, v := range golden {
-		ctx, err := base.ParseUrl(k, -1)
-		hls.Log.Assert(nil, err)
-		out := dps.GetRequestInfo(ctx, rootOutPath)
-		assert.Equal(t, v, out)
+	dps := &hls.DefaultPathStrategy{}
+	rootOutPath := "/tmp/lal/hls/"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, err := base.ParseUrl(tc.url, -1)
+			hls.Log.Assert(nil, err)
+			out := dps.GetRequestInfo(ctx, rootOutPath)
+			tmp := hls.RequestInfo{
+				StreamName:       tc.wantStreamName,
+				FileNameWithPath: tc.wantFileNameWithPath,
+			}
+			if runtime.GOOS == "windows" {
+				tmp.FileNameWithPath = tc.wantWinFileNameWithPath
+			}
+			assert.Equal(t, tmp, out)
+		})
 	}
 }


### PR DESCRIPTION
分别在win10 mac linux上测试成功 
异常情况返回为原本流名称 如aaa-1620540712084.ts (不满足目前%s-%d-%d.ts格式）