### PR TITLE
[add] amf0: 增加amf0 EcmaArray结束标识

### DIFF
--- a/pkg/rtmp/amf0.go
+++ b/pkg/rtmp/amf0.go
@@ -48,7 +48,11 @@ const (
 	//Amf0TypeMarkerTypedObject = uint8(0x10)
 )
 
-var Amf0TypeMarkerObjectEndBytes = []byte{0, 0, Amf0TypeMarkerObjectEnd}
+var (
+	// object-end-type(0x00 0x00 0x09) 表示Object和EcmaArray类型的结束标识
+	Amf0TypeMarkerObjectEndBytes = []byte{0, 0, Amf0TypeMarkerObjectEnd}
+	Amf0TypeMarkerArrayEndBytes  = []byte{0, 0, Amf0TypeMarkerObjectEnd}
+)
 
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -396,10 +400,9 @@ func (amf0) ReadArray(b []byte) (ObjectPairArray, int, error) {
 		}
 	}
 
-	if len(b)-index >= 3 && bytes.Equal(b[index:index+3], Amf0TypeMarkerObjectEndBytes) {
+	if len(b)-index >= 3 && bytes.Equal(b[index:index+3], Amf0TypeMarkerArrayEndBytes) {
 		index += 3
 	} else {
-		// 测试时发现Array最后也是以00 00 09结束，不确定是否是标准规定的，加个日志在这
 		Log.Warn("amf ReadArray without suffix Amf0TypeMarkerObjectEndBytes.")
 	}
 	return ops, index, nil

--- a/pkg/rtmp/chunk_composer.go
+++ b/pkg/rtmp/chunk_composer.go
@@ -270,7 +270,7 @@ func (c *ChunkComposer) RunLoop(reader io.Reader, cb OnCompleteMessage) error {
 
 		// TODO(chef): 这里应该永远执行不到，可以删除掉
 		if stream.msg.Len() > stream.header.MsgLen {
-			return base.NewErrRtmpShortBuffer(int(stream.header.MsgLen), int(stream.msg.Len()), "len of msg bigger tthan msg len of header")
+			return base.NewErrRtmpShortBuffer(int(stream.header.MsgLen), int(stream.msg.Len()), "len of msg bigger than msg len of header")
 		}
 	}
 }


### PR DESCRIPTION
根据amf0文档描述：EcmaArray和Object类型都使用object-end-type(0x00 0x00 0x09)作为结束标识。
原文：The object-end-marker is used in a special type that signals the end of a set of object properties in an anonymous object or typed object or associative array. 
其中associative array为即ECMA Array Type。