### PR TITLE
fix: audio chunk and video chunk mixd bug

### DIFF
--- a/pkg/rtmp/chunk_composer.go
+++ b/pkg/rtmp/chunk_composer.go
@@ -64,7 +64,6 @@ type OnCompleteMessage func(stream *Stream) error
 func (c *ChunkComposer) RunLoop(reader io.Reader, cb OnCompleteMessage) error {
 	var aggregateStream *Stream
 	bootstrap := make([]byte, 11)
-	absTsFlag := false
 
 	for {
 		// 5.3.1.1. Chunk Basic Header
@@ -104,7 +103,7 @@ func (c *ChunkComposer) RunLoop(reader io.Reader, cb OnCompleteMessage) error {
 			// 包头中为绝对时间戳
 			stream.timestamp = bele.BeUint24(bootstrap)
 			stream.header.TimestampAbs = stream.timestamp
-			absTsFlag = true
+			stream.absTsFlag = true
 			stream.header.MsgLen = bele.BeUint24(bootstrap[3:])
 			stream.header.MsgTypeId = bootstrap[6]
 			stream.header.MsgStreamId = int(bele.LeUint32(bootstrap[7:]))
@@ -189,11 +188,11 @@ func (c *ChunkComposer) RunLoop(reader io.Reader, cb OnCompleteMessage) error {
 			}
 
 			stream.header.Csid = csid
-			if !absTsFlag {
+			if !stream.absTsFlag {
 				// 这么处理相当于取最后一个chunk的时间戳差值，有的协议栈是取的第一个，正常来说都可以
 				stream.header.TimestampAbs += stream.timestamp
 			}
-			absTsFlag = false
+			stream.absTsFlag = false
 			if Log.GetOption().Level == nazalog.LevelTrace {
 				tmpMsg := stream.toAvMsg()
 				maxLength := 32

--- a/pkg/rtmp/chunk_composer_test.go
+++ b/pkg/rtmp/chunk_composer_test.go
@@ -1,0 +1,88 @@
+package rtmp
+
+import (
+	"bytes"
+	"github.com/q191201771/lal/pkg/base"
+	"github.com/q191201771/naza/pkg/assert"
+	"testing"
+	"time"
+)
+
+func TestChunkComposer(t *testing.T) {
+
+	//case: 音视频混合发送的时候测试case
+
+	//video payload 50
+	//chunk size = 20
+	videoMsg := base.RtmpMsg{
+		Header: base.RtmpHeader{
+			Csid:         6,
+			MsgLen:       50,
+			MsgTypeId:    base.RtmpTypeIdVideo,
+			MsgStreamId:  Msid1,
+			TimestampAbs: 1000,
+		},
+		Payload: make([]byte, 50),
+	}
+	//fmt = 0
+	videoChunk1 := []byte{6, 0, 3, 232, 0, 0, 50, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	//fmt = 3
+	videoChunk2 := []byte{198, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	//fmt = 3
+	videoChunk3 := []byte{198, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	//audio payload 15
+	//chunk size = 20
+	//ah :=
+	audioMsg := base.RtmpMsg{
+		Header: base.RtmpHeader{
+			Csid:         5,
+			MsgLen:       15,
+			MsgTypeId:    base.RtmpTypeIdAudio,
+			MsgStreamId:  Msid1,
+			TimestampAbs: 1000,
+		},
+		Payload: make([]byte, 15),
+	}
+	//fmt = 0
+	audioChunk1 := []byte{5, 0, 3, 232, 0, 0, 15, 8, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	rb := &bytes.Buffer{}
+	rb.Write(videoChunk1)
+	rb.Write(videoChunk2)
+	rb.Write(audioChunk1)
+	rb.Write(videoChunk3)
+
+	cc := NewChunkComposer()
+	cc.peerChunkSize = 20
+
+	done := make(chan struct{}, 1)
+	c := 2
+
+	go cc.RunLoop(rb, func(stream *Stream) error {
+		if stream.header.MsgTypeId == base.RtmpTypeIdVideo {
+			assert.Equal(t, videoMsg.Header.TimestampAbs, stream.toAvMsg().Header.TimestampAbs)
+			assert.Equal(t, videoMsg.Payload, stream.msg.buff.Bytes())
+			c--
+		} else if stream.header.MsgTypeId == base.RtmpTypeIdAudio {
+			assert.Equal(t, audioMsg.Header.TimestampAbs, stream.toAvMsg().Header.TimestampAbs)
+			assert.Equal(t, audioMsg.Payload, stream.toAvMsg().Payload)
+			c--
+		}
+
+		if c == 0 {
+			done <- struct{}{}
+		}
+		return nil
+	})
+
+	timer := time.NewTimer(1 * time.Second)
+
+	select {
+	case <-timer.C:
+		assert.Equal(t, "", "error", "unit test timeout")
+		break
+	case <-done:
+		break
+	}
+}

--- a/pkg/rtmp/stream.go
+++ b/pkg/rtmp/stream.go
@@ -23,6 +23,7 @@ type Stream struct {
 	header base.RtmpHeader
 	msg    StreamMsg
 
+	absTsFlag bool   // 标记当这个stream收到新的msg的时候，是否收到过绝对时间
 	timestamp uint32 // 注意，是rtmp chunk协议header中的时间戳，可能是绝对的，也可能是相对的。上层不应该使用这个字段，而应该使用Header.TimestampAbs
 }
 


### PR DESCRIPTION
当音频message的chunk和视频message的chunk混合发送时，会有时间戳计算错误的问题。

现在判断一个message有没有接收到带绝对时间戳的chunk是在整个链接维度判断，应该是以流维度判断。

case情况如下：
视频有2个chunk
音频只有1个chunk
1. fmt = 0， abstsflag = ture，type = vidoe
2. fmt = 0， abstsflag = true，type = audio =》 达到一个完整的message，重设置abstsflag = false
3. fmt = 3，abstsflag = false，type = video =》 达到一个完整的message，判断没有收到完整的带绝对时间戳的chunk，这个时候会将时间偏移加上上一次的绝对时间戳，计算出一个错误的时间戳。
