### PR TITLE
Allow fragment_duration_ms to be under thousands

### DIFF
--- a/pkg/logic/group__.go
+++ b/pkg/logic/group__.go
@@ -157,7 +157,7 @@ func NewGroup(appName string, streamName string, config *Config, observer IGroup
 		httpflvGopCache:               remux.NewGopCache("httpflv", uk, config.HttpflvConfig.GopNum, config.HttpflvConfig.SingleGopMaxFrameNum),
 		httptsGopCache:                remux.NewGopCacheMpegts(uk, config.HttptsConfig.GopNum, config.HttptsConfig.SingleGopMaxFrameNum),
 		psPubPrevInactiveCheckTick:    -1,
-		hlsCalcSessionStatIntervalSec: uint32(config.HlsConfig.FragmentDurationMs/1000) * 10,
+		hlsCalcSessionStatIntervalSec: uint32(config.HlsConfig.FragmentDurationMs/100),
 	}
 
 	g.initRelayPushByConfig()


### PR DESCRIPTION
// simplifing logic to enable fragment_duration_ms on configuration to be under thousands (but not below hundreds) 

Hi, 
This pull request simplifies logic on a single line, allowing users to set fragment_duration_ms on the config file a value on the hundreds.
Due to rounding numbers on the previous logic anything below '1000' would be rounded to zero and at some point that value is used as a divisor causing an runtime error(pasted on the end of this pull request)

I haven't tested all functionalities myself since changing the code, but hls streaming is working just fine now with  fragment_duration_ms below a thousand and the test shell script had the same results before and after my change.

If due to code readability the UINT32(X/1000)\*10 is meaningful to be kept, I'd suggest  inverting the order of the calculation.
As in UINT32((X\*10)/1000) 

 ```
  - group__core_streaming.go:188
2023/03/28 19:47:30.991206 DEBUG [GROUP1] cache rtmp metadata. size:417 - gop_cache.go:93
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/q191201771/lal/pkg/logic.(*Group).Tick(0xc000354000, 0x7)
        /home/USER/lal/pkg/logic/group__.go:198 +0x20a
github.com/q191201771/lal/pkg/logic.(*ServerManager).RunLoop.func10(0xc000354000)
        /home/USER/lal/pkg/logic/server_manager__.go:305 +0xd7
github.com/q191201771/lal/pkg/logic.(*SimpleGroupManager).Iterate(0xc00011e2e8, 0xc0001d6d60)
        /home/USER/lal/pkg/logic/group_manager.go:83 +0xab
github.com/q191201771/lal/pkg/logic.(*ServerManager).RunLoop(0xc000115860)
        /home/USER/lal/pkg/logic/server_manager__.go:298 +0x9ea
main.main()
        /home/USER/lal/app/lalserver/main.go:30 +0x8e
 ```
 