### PR TITLE
[fix] 修改是否升级成websocket判断 兼容火狐浏览器

### DIFF
--- a/pkg/logic/http_server_handler.go
+++ b/pkg/logic/http_server_handler.go
@@ -61,7 +61,8 @@ func (h *HttpServerHandler) ServeSubSession(writer http.ResponseWriter, req *htt
 		isWebSocket  bool
 		webSocketKey string
 	)
-	if req.Header.Get("Connection") == "Upgrade" && req.Header.Get("Upgrade") == "websocket" {
+	// 火狐浏览器 Connection = [keep-alive, Upgrade]
+	if strings.Contains(req.Header.Get("Connection"), "Upgrade") && req.Header.Get("Upgrade") == "websocket" {
 		isWebSocket = true
 		webSocketKey = req.Header.Get("Sec-WebSocket-Key")
 	}


### PR DESCRIPTION
火狐浏览器ws请求时 Connection = [keep-alive, Upgrade]
目前是根据RFC 6455标准例子判断Connection=Upgrade
会导致火狐浏览器ws升级失败
根据RFC 2616修改为Connection包含Upgrade即可