### PR TITLE
修复hls拉流时 因为流名称带.符号失败

### DIFF
--- a/pkg/base/url.go
+++ b/pkg/base/url.go
@@ -74,10 +74,9 @@ func (u *UrlContext) GetFileType() string {
 
 func (u *UrlContext) calcFilenameAndTypeIfNeeded() {
 	if len(u.filenameWithoutType) == 0 || len(u.fileType) == 0 {
-		ss := strings.Split(u.LastItemOfPath, ".")
-		u.filenameWithoutType = ss[0]
-		if len(ss) > 1 {
-			u.fileType = ss[1]
+		if index := strings.LastIndex(u.LastItemOfPath, "."); index != -1 {
+			u.filenameWithoutType = u.LastItemOfPath[:index]
+			u.fileType = u.LastItemOfPath[index+1:]
 		}
 	}
 }

--- a/pkg/base/url_test.go
+++ b/pkg/base/url_test.go
@@ -10,6 +10,7 @@ package base_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/q191201771/lal/pkg/base"
@@ -294,4 +295,28 @@ func testParseRtmpUrlCase2(t *testing.T) {
 	assert.Equal(t, "vhall?vhost=thirdVhost?token=2A317D14t25690", appNameFn(ctx))
 	assert.Equal(t, "rtmp://xxx.net/vhall?vhost=thirdVhost?token=2A317D14t25690", tcUrlFn(ctx))
 	assert.Equal(t, "138521921", streamNameWithRawQueryFn(ctx))
+}
+
+func FuzzGetFilenameWithoutTypeAndGetFileType(f *testing.F) {
+	testcases := []string{
+		"playlist.m3u8",
+		"abcABC123.ts",
+		"192.168.1.68-1699692546341-2.ts",
+	}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	re := regexp.MustCompile(`.+\.[^.]+`)
+	f.Fuzz(func(t *testing.T, orig string) {
+		if !re.MatchString(orig) {
+			return
+		}
+		tmp := base.UrlContext{LastItemOfPath: orig}
+		filenameWithoutType := tmp.GetFilenameWithoutType()
+		fileType := tmp.GetFileType()
+		if orig != filenameWithoutType+"."+fileType {
+			t.Errorf("expected: [%s], actual: [%s.%s]",
+				orig, filenameWithoutType, fileType)
+		}
+	})
 }


### PR DESCRIPTION

| 流名称 | 播放情况 | 播放地址 |
| :-----| ----: | :----: |
| test | 正常|http://192.168.1.68:2368/hls/test/playlist.m3u8 |
| 192.168.1.68 | 失败 | http://192.168.1.68:2368/hls/192.168.1.68/playlist.m3u8|