### PR TITLE
[fix] rtmp: panic in SetChunkSize msg

### DIFF
--- a/pkg/rtmp/chunk_composer.go
+++ b/pkg/rtmp/chunk_composer.go
@@ -183,8 +183,10 @@ func (c *ChunkComposer) RunLoop(reader io.Reader, cb OnCompleteMessage) error {
 		if stream.msg.Len() == stream.header.MsgLen {
 			// 对端设置了chunk size
 			if stream.header.MsgTypeId == base.RtmpTypeIdSetChunkSize {
-				val := bele.BeUint32(stream.msg.buff.Bytes())
-				c.SetPeerChunkSize(val)
+				if buf := stream.msg.buff.Bytes(); len(buf) >= 4 {
+					val := bele.BeUint32(buf)
+					c.SetPeerChunkSize(val)
+				}
 			}
 
 			stream.header.Csid = csid


### PR DESCRIPTION
```
panic: runtime error: index out of range [3] with length 0

goroutine 115834580 [running]:
encoding/binary.bigEndian.Uint32(...)
        /usr/local/go/src/encoding/binary/binary.go:157
github.com/q191201771/naza/pkg/bele.BeUint32(...)
        /home/jaesung/go/pkg/mod/github.com/q191201771/naza@v0.30.48/pkg/bele/bele.go:35
github.com/q191201771/lal/pkg/rtmp.(*ChunkComposer).RunLoop(0xc005c87ba0, {0x7f268208a638, 0xc017ab1c30}, 0xc01bcebf38)
        /home/jaesung/src/lal/pkg/rtmp/chunk_composer.go:186 +0x187e
github.com/q191201771/lal/pkg/rtmp.(*ServerSession).runReadLoop(...)
        /home/jaesung/src/lal/pkg/rtmp/server_session.go:201
github.com/q191201771/lal/pkg/rtmp.(*ServerSession).RunLoop(0xc00162e540)
        /home/jaesung/src/lal/pkg/rtmp/server_session.go:132 +0xbc
github.com/q191201771/lal/pkg/rtmp.(*Server).handleTcpConnect(0xc000416270, {0x10d41d0, 0xc00513e700})
        /home/jaesung/src/lal/pkg/rtmp/server.go:102 +0xe5
created by github.com/q191201771/lal/pkg/rtmp.(*Server).RunLoop
        /home/jaesung/src/lal/pkg/rtmp/server.go:86 +0x25
```