### PR TITLE
rtsp server support rtsp-over-websocket play

### DIFF
--- a/conf/lalserver.conf.json
+++ b/conf/lalserver.conf.json
@@ -60,7 +60,9 @@
     "auth_enable": false,
     "auth_method": 1,
     "username": "q191201771",
-    "password": "pengrl"
+    "password": "pengrl",
+    "ws_rtsp_enable": true,
+    "ws_rtsp_addr": ":5566"
   },
   "record": {
     "enable_flv": false,

--- a/pkg/base/basic_http_sub_session.go
+++ b/pkg/base/basic_http_sub_session.go
@@ -59,7 +59,7 @@ func (session *BasicHttpSubSession) Dispose() error {
 
 func (session *BasicHttpSubSession) WriteHttpResponseHeader(b []byte) {
 	if session.IsWebSocket {
-		session.write(UpdateWebSocketHeader(session.WebSocketKey))
+		session.write(UpdateWebSocketHeader(session.WebSocketKey, ""))
 	} else {
 		session.write(b)
 	}

--- a/pkg/logic/config.go
+++ b/pkg/logic/config.go
@@ -102,6 +102,8 @@ type RtspConfig struct {
 	RtspsCertFile       string `json:"rtsps_cert_file"`
 	RtspsKeyFile        string `json:"rtsps_key_file"`
 	OutWaitKeyFrameFlag bool   `json:"out_wait_key_frame_flag"`
+	WsRtspEnable        bool   `json:"ws_rtsp_enable"`
+	WsRtspAddr          string `json:"ws_rtsp_addr"`
 	rtsp.ServerAuthConfig
 }
 

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -140,7 +140,7 @@ func (s *Server) OnDelRtspSubSession(session *SubSession) {
 // ---------------------------------------------------------------------------------------------------------------------
 
 func (s *Server) handleTcpConnect(conn net.Conn) {
-	session := NewServerCommandSession(s, conn, s.auth)
+	session := NewServerCommandSession(s, conn, s.auth, false, "")
 	s.observer.OnNewRtspSessionConnect(session)
 
 	err := session.RunLoop()

--- a/pkg/rtsp/websocket_server.go
+++ b/pkg/rtsp/websocket_server.go
@@ -1,0 +1,110 @@
+package rtsp
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/q191201771/lal/pkg/base"
+)
+
+type WebsocketServer struct {
+	addr     string
+	observer IServerObserver
+
+	ln         net.Listener
+	auth       ServerAuthConfig
+	httpServer http.Server
+}
+
+func NewWebsocketServer(addr string, observer IServerObserver, auth ServerAuthConfig) *WebsocketServer {
+	return &WebsocketServer{
+		addr:     addr,
+		observer: observer,
+		auth:     auth,
+	}
+}
+
+func (s *WebsocketServer) Listen() (err error) {
+	s.ln, err = net.Listen("tcp", s.addr)
+	if err != nil {
+		return
+	}
+	Log.Infof("start ws rtsp server listen. addr=%s", s.addr)
+
+	server := http.Server{
+		Handler: http.HandlerFunc(s.HandleWebsocket),
+	}
+	server.Serve(s.ln)
+	return
+}
+
+func (s *WebsocketServer) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
+	conn, bio, err := w.(http.Hijacker).Hijack()
+	if err != nil {
+		Log.Errorf("hijack failed. err=%+v", err)
+		return
+	}
+	if bio.Reader.Buffered() != 0 || bio.Writer.Buffered() != 0 {
+		Log.Errorf("hijack but buffer not empty. rb=%d, wb=%d", bio.Reader.Buffered(), bio.Writer.Buffered())
+	}
+
+	var (
+		isWebSocket  bool
+		webSocketKey string
+	)
+	// 火狐浏览器 Connection = [keep-alive, Upgrade]
+	if strings.Contains(r.Header.Get("Connection"), "Upgrade") && r.Header.Get("Upgrade") == "websocket" {
+		isWebSocket = true
+		webSocketKey = r.Header.Get("Sec-WebSocket-Key")
+	}
+
+	session := NewServerCommandSession(s, conn, s.auth, isWebSocket, webSocketKey)
+	s.observer.OnNewRtspSessionConnect(session)
+
+	session.conn.Write(base.UpdateWebSocketHeader(webSocketKey, "rtsp"))
+
+	err = session.RunLoop()
+	Log.Info(err)
+
+	if session.pubSession != nil {
+		s.observer.OnDelRtspPubSession(session.pubSession)
+		_ = session.pubSession.Dispose()
+	} else if session.subSession != nil {
+		s.observer.OnDelRtspSubSession(session.subSession)
+		_ = session.subSession.Dispose()
+	}
+	s.observer.OnDelRtspSession(session)
+
+}
+
+func (s *WebsocketServer) Dispose() {
+	if s.ln == nil {
+		return
+	}
+	if err := s.ln.Close(); err != nil {
+		Log.Error(err)
+	}
+}
+
+// ----- ServerCommandSessionObserver ----------------------------------------------------------------------------------
+
+func (s *WebsocketServer) OnNewRtspPubSession(session *PubSession) error {
+	return s.observer.OnNewRtspPubSession(session)
+}
+
+func (s *WebsocketServer) OnNewRtspSubSessionDescribe(session *SubSession) (ok bool, sdp []byte) {
+	return s.observer.OnNewRtspSubSessionDescribe(session)
+}
+
+func (s *WebsocketServer) OnNewRtspSubSessionPlay(session *SubSession) error {
+	return s.observer.OnNewRtspSubSessionPlay(session)
+}
+
+func (s *WebsocketServer) OnDelRtspPubSession(session *PubSession) {
+	s.observer.OnDelRtspPubSession(session)
+}
+
+func (s *WebsocketServer) OnDelRtspSubSession(session *SubSession) {
+	s.observer.OnDelRtspSubSession(session)
+}


### PR DESCRIPTION
rtsp支持rtsp over websocket播放，该方案支持在web上直接播放rtsp，无需安装控件，也不需要使用ffmpeg将流转成mpeg1video给jsmpeg去播放，原理和flv.js一样由web播放器将流转成fmp4给mse进行播放，可以使用这个测试

https://github.com/cnotch/ipchub/tree/main/demos/rtsp

注：对于B帧处理不好，可以推流时将B帧去除