### PR TITLE
防止音频流无数据时 panic

### DIFF
--- a/pkg/remux/avpacket2rtmp.go
+++ b/pkg/remux/avpacket2rtmp.go
@@ -300,6 +300,9 @@ func (r *AvPacket2RtmpRemuxer) FeedAvPacket(pkt base.AvPacket) {
 			}
 
 			length := len(pkt.Payload) - 5 // -7+2
+			if length < 7 {
+				return
+			}
 			payload := make([]byte, length)
 			payload[0] = 0xAF
 			payload[1] = base.RtmpAacPacketTypeRaw


### PR DESCRIPTION
修复 #342 

如图所示，收到空数据的音频流，创建负数的数组或下标溢出会导致 panic 。
加个条件判断，防止 panic 。

<img width="1386" alt="iShot_2024-02-23_18 45 05" src="https://github.com/q191201771/lal/assets/59127546/49ff7fde-1611-4de9-babe-f74382d9391e">
